### PR TITLE
feat: clicking on an item routes user to that item's "Edit item" page, allowing it to be edited and deleted

### DIFF
--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -214,6 +214,14 @@ thead > tr {
 	background-color: #f4f4f4;
 }
 
+tbody > tr {
+	cursor: pointer;
+
+	&:hover {
+		background-color: hsl(45, 90%, 96%);
+	}
+}
+
 td,
 th {
 	padding: 0.75rem 2rem;

--- a/src/views/pages/allItems/itemsTable.ejs
+++ b/src/views/pages/allItems/itemsTable.ejs
@@ -11,7 +11,7 @@
   </thead>
   <tbody>
     <% items.forEach(item => { %>
-    <tr>
+    <tr onclick="window.location='<%= `/items/${item.id}` %>'" aria-label="See more details of item">
       <td><%= item.name %></td>
       <td><%= item.sku %></td>
       <td class="align-right"><%= Math.round(item.size_grams) %>g</td>


### PR DESCRIPTION
removes the action buttons for a cleaner UI on `itemsTable.ejs`:
<img width="2556" height="1165" alt="image" src="https://github.com/user-attachments/assets/e9a083ad-7be5-4473-8bfb-cb6d9300aed8" />

this is a workaround for #7, which I was struggling to find a way for each of the row's "Delete" button to confirm and then delete that particular item from database.