### PR TITLE
feat: items that the user marked as for deletion (by clicking their bin buttons on UI) have their IDs registered and passed into db query for orphaning

### DIFF
--- a/src/controllers/categoriesController.js
+++ b/src/controllers/categoriesController.js
@@ -92,6 +92,7 @@ exports.editCategoryPost = [
 			await db.orphanItems(itemIdsForOrphaning);
 
 		await db.updateCategoryDetails(categoryId, formObject);
+		res.redirect("/categories");
 	},
 ];
 

--- a/src/db/queries.js
+++ b/src/db/queries.js
@@ -119,12 +119,9 @@ const updateCategoryDetails = async (categoryId, formObject) => {
 
 const orphanItems = async (itemIdsArray) => {
 	if (!Array.isArray(itemIdsArray) || itemIdsArray.length === 0) return;
-	const testSelect = await pool.query(
-		"SELECT * FROM items WHERE id = ANY($1);",
-		[itemIdsArray],
-	);
-	console.log(testSelect.rows);
-	// await pool.query("UPDATE items SET category_id = NULL WHERE id = ")
+	await pool.query("UPDATE items SET category_id = NULL WHERE id = ANY($1);", [
+		itemIdsArray,
+	]);
 };
 
 const deleteCategoryAndOrphanItems = async (categoryId) => {


### PR DESCRIPTION
the array `itemIdsforOrphaning` is in the request's body, from the front-end (`compositeItems.ejs`' `<script>` tag, via `fetch`). inside of `categoriesController.editCategoryPost` method (now server-side), we check if the array is an array (helps defend against it being undefined and then throwing error) and if it has any elements in it. if yes to both, we call the `db.orphanItems` query, passing in an array of item IDs. if not, then we don't call the query.

on the `db.queries` side, we also do an early return just in case something slipped through, then use itemised parameters and the `ANY(...)` postgres function to handle the array. This is way more elegant (and I think, maybe performant?) than doing a for loop over the `itemIdsArray`

also fixed a minor bug (caused by me) that prevented the page from redirecting back to "All categories" after saving. Still need to added a:
```js
res.redirect("/categories")
```
on server-side.

ps really starting to think #85 is necessary here...