### PR TITLE
fix: page navigations

### DIFF
--- a/public/js/editItemScript.js
+++ b/public/js/editItemScript.js
@@ -5,32 +5,6 @@ function handleKeydownOnNumberInputs(event) {
 	}
 }
 
-function setCancelBtnHref() {
-	const QUERY_KEYS = {
-		referredPageViewName: "fromPage",
-		referredCategoryId: "referredCategoryId",
-	};
-
-	const cancelBtn = document.querySelector(".cancel-btn");
-
-	const params = new URL(document.location.toString()).searchParams;
-	const referredCategoryId = params.get(QUERY_KEYS.referredCategoryId);
-	const referredPageViewName = params.get(QUERY_KEYS.referredPageViewName);
-
-	if (referredCategoryId === null) {
-		cancelBtn.href = "/items";
-		return;
-	}
-
-	if (referredPageViewName === null || referredPageViewName === "category") {
-		cancelBtn.href = `/categories/${referredCategoryId}`;
-		return;
-	}
-
-	cancelBtn.href = `/categories/${referredCategoryId}/edit-items`;
-}
-
-setCancelBtnHref();
 /* attach event listeners */
 const form = document.querySelector("form");
 const numberInputs = form.querySelectorAll('input[type="number"]');

--- a/public/js/editItemScript.js
+++ b/public/js/editItemScript.js
@@ -5,6 +5,32 @@ function handleKeydownOnNumberInputs(event) {
 	}
 }
 
+function setCancelBtnHref() {
+	const QUERY_KEYS = {
+		referredPageViewName: "fromPage",
+		referredCategoryId: "referredCategoryId",
+	};
+
+	const cancelBtn = document.querySelector(".cancel-btn");
+
+	const params = new URL(document.location.toString()).searchParams;
+	const referredCategoryId = params.get(QUERY_KEYS.referredCategoryId);
+	const referredPageViewName = params.get(QUERY_KEYS.referredPageViewName);
+
+	if (referredCategoryId === null) {
+		cancelBtn.href = "/items";
+		return;
+	}
+
+	if (referredPageViewName === null || referredPageViewName === "category") {
+		cancelBtn.href = `/categories/${referredCategoryId}`;
+		return;
+	}
+
+	cancelBtn.href = `/categories/${referredCategoryId}/edit-items`;
+}
+
+setCancelBtnHref();
 /* attach event listeners */
 const form = document.querySelector("form");
 const numberInputs = form.querySelectorAll('input[type="number"]');

--- a/src/controllers/itemsController.js
+++ b/src/controllers/itemsController.js
@@ -13,25 +13,43 @@ const getItemById = async (itemId) => {
 	return item;
 };
 
-const getRoutes = async (referredCategoryId) => {
-	const routes = {};
+// const getRoutes = async (referredCategoryId) => {
+// 	const routes = {};
 
-	routes.formSubmitRoute = referredCategoryId
-		? `/items/new?referredCategoryId=${referredCategoryId}`
-		: "/items/new";
+// 	routes.formSubmitRoute = referredCategoryId
+// 		? `/items/new?referredCategoryId=${referredCategoryId}`
+// 		: "/items/new";
 
-	routes.redirectRoute = referredCategoryId
-		? `/categories/${referredCategoryId}` // TODO: THIS NEEDS TO BE FIXED - NEEDS TO GO TO THE MANAGE ITEMS PAGE
-		: "/items";
+// 	routes.redirectRoute = referredCategoryId
+// 		? `/categories/${referredCategoryId}` // TODO: THIS NEEDS TO BE FIXED - NEEDS TO GO TO THE MANAGE ITEMS PAGE
+// 		: "/items";
 
-	return routes;
-};
+// 	return routes;
+// };
 
 const getEditItemButtonRoute = (categoryIdQueryValue, fromPageQueryValue) => {
 	if (!categoryIdQueryValue) return "/items";
 	if (fromPageQueryValue === "category")
 		return `/categories/${categoryIdQueryValue}`;
 	else return `/categories/${categoryIdQueryValue}/edit-items`;
+};
+
+// const getRoutes = (req, basePath, allItemsPath = "/items") => {
+//   const { referredCategoryId, fromPage } = req.query;
+//   const routes = { formSubmitRoute: "/", redirectRoute: allItemsPath };
+
+//   if
+// };
+
+const getPathsForNewItemPage = (req) => {
+	const { referredCategoryId } = req.query;
+	const paths = { submit: "/items/new", previousPage: "/items" };
+	if (referredCategoryId) {
+		paths.submit = `/items/new?referredCategoryId=${referredCategoryId}`;
+		paths.previousPage = `/categories/${referredCategoryId}/edit-items`;
+	}
+
+	return paths;
 };
 
 exports.getAllItems = async (_req, res) => {
@@ -49,13 +67,11 @@ exports.getAllItems = async (_req, res) => {
 };
 
 exports.createItemGet = async (req, res) => {
-	const { referredCategoryId } = req.query;
-
-	const routes = await getRoutes(referredCategoryId);
+	const paths = getPathsForNewItemPage(req);
 
 	res.render("pages/newItem", {
 		title: "Create new item",
-		routes,
+		paths,
 	});
 };
 
@@ -63,13 +79,13 @@ exports.createItemPost = [
 	validateItem,
 	async (req, res) => {
 		const { referredCategoryId } = req.query;
-		const routes = await getRoutes(referredCategoryId);
+		const paths = getPathsForNewItemPage(req);
 
 		const errors = validationResult(req);
 		if (!errors.isEmpty())
 			return res
 				.status(400)
-				.render("pages/newItem", { errors: errors.array(), routes });
+				.render("pages/newItem", { errors: errors.array(), paths });
 
 		const { price_dollars, ...unchangedFormInputsAndValues } = matchedData(req);
 		const formInputsAndValues = {
@@ -79,7 +95,7 @@ exports.createItemPost = [
 		};
 
 		await db.addItem(formInputsAndValues);
-		res.redirect(routes.redirectRoute);
+		res.redirect(paths.previousPage);
 	},
 ];
 

--- a/src/controllers/itemsController.js
+++ b/src/controllers/itemsController.js
@@ -13,34 +13,6 @@ const getItemById = async (itemId) => {
 	return item;
 };
 
-// const getRoutes = async (referredCategoryId) => {
-// 	const routes = {};
-
-// 	routes.formSubmitRoute = referredCategoryId
-// 		? `/items/new?referredCategoryId=${referredCategoryId}`
-// 		: "/items/new";
-
-// 	routes.redirectRoute = referredCategoryId
-// 		? `/categories/${referredCategoryId}` // TODO: THIS NEEDS TO BE FIXED - NEEDS TO GO TO THE MANAGE ITEMS PAGE
-// 		: "/items";
-
-// 	return routes;
-// };
-
-const getEditItemButtonRoute = (categoryIdQueryValue, fromPageQueryValue) => {
-	if (!categoryIdQueryValue) return "/items";
-	if (fromPageQueryValue === "category")
-		return `/categories/${categoryIdQueryValue}`;
-	else return `/categories/${categoryIdQueryValue}/edit-items`;
-};
-
-// const getRoutes = (req, basePath, allItemsPath = "/items") => {
-//   const { referredCategoryId, fromPage } = req.query;
-//   const routes = { formSubmitRoute: "/", redirectRoute: allItemsPath };
-
-//   if
-// };
-
 const getPathsForNewItemPage = (req) => {
 	const { referredCategoryId } = req.query;
 	const paths = { submit: "/items/new", previousPage: "/items" };
@@ -48,6 +20,24 @@ const getPathsForNewItemPage = (req) => {
 		paths.submit = `/items/new?referredCategoryId=${referredCategoryId}`;
 		paths.previousPage = `/categories/${referredCategoryId}/edit-items`;
 	}
+
+	return paths;
+};
+
+const getPathsForEditItemPage = (req) => {
+	const { referredCategoryId, fromPage } = req.query;
+	const { id: itemId } = req.params;
+	const paths = { submit: `/items/${itemId}/update`, previousPage: "/items" };
+
+	if (!referredCategoryId) return paths;
+	paths.submit =
+		`/items/${itemId}/update` +
+		`?referredCategoryId=${referredCategoryId}` +
+		`&fromPage=${fromPage}`;
+
+	if (fromPage.includes("edit"))
+		paths.previousPage = `/categories/${referredCategoryId}/edit-items`;
+	else paths.previousPage = `/categories/${referredCategoryId}`;
 
 	return paths;
 };
@@ -100,34 +90,32 @@ exports.createItemPost = [
 ];
 
 exports.editItemGet = async (req, res) => {
-	const { referredCategoryId, fromPage } = req.query;
 	const { id: itemId } = req.params;
 	const fetchedItem = await getItemById(itemId);
+
+	const paths = getPathsForEditItemPage(req);
 
 	res.render("pages/editItem", {
 		title: fetchedItem.name,
 		item: fetchedItem,
-		buttonRoutes: {
-			formSubmitRoute: !referredCategoryId
-				? `/items/${itemId}/update`
-				: `/items/${itemId}/update?referredCategoryId=${referredCategoryId}&fromPage=${fromPage}`,
-			cancelBtn: getEditItemButtonRoute(referredCategoryId, fromPage),
-		},
+		paths,
 	});
 };
 
 exports.editItemPost = [
 	validateItem,
 	async (req, res) => {
-		const { referredCategoryId, fromPage } = req.query;
 		const { id: itemId } = req.params;
 		const fetchedItem = await getItemById(itemId);
+
+		const paths = getPathsForEditItemPage(req);
 
 		const errors = validationResult(req);
 		if (!errors.isEmpty())
 			return res.status(400).render("pages/editItem", {
 				item: fetchedItem,
 				errors: errors.array(),
+				paths,
 			});
 
 		const { price_dollars, ...unchangedFormInputsAndValues } = matchedData(req);
@@ -138,7 +126,7 @@ exports.editItemPost = [
 		};
 
 		await db.updateItemById(itemId, formInputsAndValues);
-		res.redirect(getEditItemButtonRoute(referredCategoryId, fromPage));
+		res.redirect(paths.previousPage);
 	},
 ];
 

--- a/src/controllers/itemsController.js
+++ b/src/controllers/itemsController.js
@@ -27,6 +27,13 @@ const getRoutes = async (referredCategoryId) => {
 	return routes;
 };
 
+const getEditItemButtonRoute = (categoryIdQueryValue, fromPageQueryValue) => {
+	if (!categoryIdQueryValue) return "/items";
+	if (fromPageQueryValue === "category")
+		return `/categories/${categoryIdQueryValue}`;
+	else return `/categories/${categoryIdQueryValue}/edit-items`;
+};
+
 exports.getAllItems = async (_req, res) => {
 	const fetchedItems = await db.getAllItems();
 
@@ -81,18 +88,14 @@ exports.editItemGet = async (req, res) => {
 	const { id: itemId } = req.params;
 	const fetchedItem = await getItemById(itemId);
 
-	const getButtonRoute = (categoryIdQueryValue, fromPageQueryValue) => {
-		if (!categoryIdQueryValue) return "/items";
-		if (fromPageQueryValue === "editItemsInCategory")
-			return `/categories/${categoryIdQueryValue}/edit-items`;
-		return `/categories/${categoryIdQueryValue}`;
-	};
-
 	res.render("pages/editItem", {
 		title: fetchedItem.name,
 		item: fetchedItem,
 		buttonRoutes: {
-			cancelBtn: getButtonRoute(referredCategoryId, fromPage),
+			formSubmitRoute: !referredCategoryId
+				? `/items/${itemId}/update`
+				: `/items/${itemId}/update?referredCategoryId=${referredCategoryId}&fromPage=${fromPage}`,
+			cancelBtn: getEditItemButtonRoute(referredCategoryId, fromPage),
 		},
 	});
 };
@@ -100,6 +103,7 @@ exports.editItemGet = async (req, res) => {
 exports.editItemPost = [
 	validateItem,
 	async (req, res) => {
+		const { referredCategoryId, fromPage } = req.query;
 		const { id: itemId } = req.params;
 		const fetchedItem = await getItemById(itemId);
 
@@ -118,7 +122,7 @@ exports.editItemPost = [
 		};
 
 		await db.updateItemById(itemId, formInputsAndValues);
-		res.redirect("/items");
+		res.redirect(getEditItemButtonRoute(referredCategoryId, fromPage));
 	},
 ];
 

--- a/src/controllers/itemsController.js
+++ b/src/controllers/itemsController.js
@@ -21,7 +21,7 @@ const getRoutes = async (referredCategoryId) => {
 		: "/items/new";
 
 	routes.redirectRoute = referredCategoryId
-		? `/categories/${referredCategoryId}`
+		? `/categories/${referredCategoryId}` // TODO: THIS NEEDS TO BE FIXED - NEEDS TO GO TO THE MANAGE ITEMS PAGE
 		: "/items";
 
 	return routes;
@@ -77,10 +77,24 @@ exports.createItemPost = [
 ];
 
 exports.editItemGet = async (req, res) => {
+	const { referredCategoryId, fromPage } = req.query;
 	const { id: itemId } = req.params;
 	const fetchedItem = await getItemById(itemId);
 
-	res.render("pages/editItem", { title: fetchedItem.name, item: fetchedItem });
+	const getButtonRoute = (categoryIdQueryValue, fromPageQueryValue) => {
+		if (!categoryIdQueryValue) return "/items";
+		if (fromPageQueryValue === "editItemsInCategory")
+			return `/categories/${categoryIdQueryValue}/edit-items`;
+		return `/categories/${categoryIdQueryValue}`;
+	};
+
+	res.render("pages/editItem", {
+		title: fetchedItem.name,
+		item: fetchedItem,
+		buttonRoutes: {
+			cancelBtn: getButtonRoute(referredCategoryId, fromPage),
+		},
+	});
 };
 
 exports.editItemPost = [

--- a/src/views/components/compositeItems.ejs
+++ b/src/views/components/compositeItems.ejs
@@ -13,7 +13,7 @@
       </thead>
       <tbody>
         <% compositeItems.forEach(item => { %>
-        <tr onclick="window.location='<%= `/items/${item.id}?referredCategoryId=${categoryId}` %>'" aria-label="See more details of item" class="hover:bg-neutral-100 hover:cursor-pointer">
+        <tr onclick="window.location='<%= `/items/${item.id}?referredCategoryId=${categoryId}&fromPage=${fromPageName}` %>'" aria-label="See more details of item" class="hover:bg-neutral-100 hover:cursor-pointer">
           <td class="pl-8 py-4"><%= item.name %></td>
           <td><%= item.sku %></td>
           <td><%= Math.round(item.size_grams) %>g</td>

--- a/src/views/components/pageHeaders/pageHeaderWithClose.ejs
+++ b/src/views/components/pageHeaders/pageHeaderWithClose.ejs
@@ -1,9 +1,9 @@
 <header class="flex items-center justify-between p-8">
   <h1 class="text-2xl"><%= heading %></h1>
-  <button class="btn btn-circle btn-ghost" onclick="history.back()">
+  <a href="<%= closeButtonPath %>" role="button" class="btn btn-circle btn-ghost">
     <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-x-icon lucide-x opacity-50">
       <path d="M18 6 6 18" />
       <path d="m6 6 12 12" />
     </svg>
-  </button>
+  </a>
 </header>

--- a/src/views/components/pageHeaders/pageHeaderWithDelete.ejs
+++ b/src/views/components/pageHeaders/pageHeaderWithDelete.ejs
@@ -2,11 +2,11 @@
   <h1 class="text-2xl">Edit <%= type %></h1>
   <div class="flex items-center gap-4">
     <button class="btn btn-outline btn-error delete-btn">Delete <%= type %></button>
-    <button class="btn btn-circle btn-ghost" onclick="history.back()">
+    <a class="btn btn-circle btn-ghost" role="button" href="<%= closeButtonPath %>">
       <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-x-icon lucide-x opacity-50">
         <path d="M18 6 6 18" />
         <path d="m6 6 12 12" />
       </svg>
-    </button>
+    </a>
   </div>
 </header>

--- a/src/views/pages/category.ejs
+++ b/src/views/pages/category.ejs
@@ -30,5 +30,5 @@
 <section class="px-8 max-w-3xl -mt-4">
   <p><%= category.description %></p>
 </section>
-<%- include("../components/compositeItems", { categoryId: category.id, compositeItems }) %>
+<%- include("../components/compositeItems", { categoryId: category.id, compositeItems, fromPageName: "category" }) %>
 <%- include ("../components/modals/deleteCategoryModal.ejs", { categoryId: category.id }) %>

--- a/src/views/pages/editItem.ejs
+++ b/src/views/pages/editItem.ejs
@@ -1,6 +1,6 @@
 <%- include("../components/pageHeaders/pageHeaderWithDelete.ejs", { type: "item" }) %>
 <section class="px-8 flex-1">
-  <%- include("../components/forms/itemForm", { item, formSubmitRoute: `/items/${item.id}/update`}) %>
+  <%- include("../components/forms/itemForm", { item, formSubmitRoute: buttonRoutes.formSubmitRoute}) %>
 </section>
 <footer class="flex gap-2 p-6 border border-base-200">
   <input type="submit" form="item-form" value="Save" class="btn btn-primary" />

--- a/src/views/pages/editItem.ejs
+++ b/src/views/pages/editItem.ejs
@@ -1,10 +1,10 @@
-<%- include("../components/pageHeaders/pageHeaderWithDelete.ejs", { type: "item" }) %>
+<%- include("../components/pageHeaders/pageHeaderWithDelete.ejs", { type: "item", closeButtonPath: paths.previousPage }) %>
 <section class="px-8 flex-1">
-  <%- include("../components/forms/itemForm", { item, formSubmitRoute: buttonRoutes.formSubmitRoute}) %>
+  <%- include("../components/forms/itemForm", { item, formSubmitRoute: paths.submit}) %>
 </section>
 <footer class="flex gap-2 p-6 border border-base-200">
   <input type="submit" form="item-form" value="Save" class="btn btn-primary" />
-  <a role="button" class="btn bg-white text-gray-500 border-gray-400 cancel-btn" href="<%= buttonRoutes.cancelBtn %>">Cancel</a>
+  <a role="button" class="btn bg-white text-gray-500 border-gray-400 cancel-btn" href="<%= paths.previousPage %>">Cancel</a>
 </footer>
 <%- include("../components/modals/deleteItemModal.ejs", { itemId: item.id }) %>
 

--- a/src/views/pages/editItem.ejs
+++ b/src/views/pages/editItem.ejs
@@ -4,7 +4,7 @@
 </section>
 <footer class="flex gap-2 p-6 border border-base-200">
   <input type="submit" form="item-form" value="Save" class="btn btn-primary" />
-  <button type="button" class="btn bg-white text-gray-500 border-gray-400" onclick="history.back()">Cancel</button>
+  <a role="button" class="btn bg-white text-gray-500 border-gray-400 cancel-btn" href="/items">Cancel</a>
 </footer>
 <%- include("../components/modals/deleteItemModal.ejs", { itemId: item.id }) %>
 

--- a/src/views/pages/editItem.ejs
+++ b/src/views/pages/editItem.ejs
@@ -4,7 +4,7 @@
 </section>
 <footer class="flex gap-2 p-6 border border-base-200">
   <input type="submit" form="item-form" value="Save" class="btn btn-primary" />
-  <a role="button" class="btn bg-white text-gray-500 border-gray-400 cancel-btn" href="/items">Cancel</a>
+  <a role="button" class="btn bg-white text-gray-500 border-gray-400 cancel-btn" href="<%= buttonRoutes.cancelBtn %>">Cancel</a>
 </footer>
 <%- include("../components/modals/deleteItemModal.ejs", { itemId: item.id }) %>
 

--- a/src/views/pages/editItemsInCategory.ejs
+++ b/src/views/pages/editItemsInCategory.ejs
@@ -22,7 +22,7 @@
     </thead>
     <tbody>
       <% items.forEach(item => { %>
-      <tr onclick="window.location='<%= `/items/${item.id}?referredCategoryId=${category.id}` %>'" aria-label="See more details of item" role="button" class="hover:cursor-pointer hover:bg-neutral-100" data-item-id="<%= item.id %>">
+      <tr onclick="window.location='<%= `/items/${item.id}?referredCategoryId=${category.id}&fromPage=editItemsInCategory` %>'" aria-label="See more details of item" role="button" class="hover:cursor-pointer hover:bg-neutral-100" data-item-id="<%= item.id %>">
         <th class="w-16">
           <label>
             <input type="checkbox" class="checkbox checkbox-primary checkbox-sm" <%= Number(item["category_id"]) === Number(category.id) 

--- a/src/views/pages/newCategory.ejs
+++ b/src/views/pages/newCategory.ejs
@@ -1,4 +1,4 @@
-<%- include("../components/pageHeaders/pageHeaderWithClose.ejs", { heading: "New category"}) %>
+<%- include("../components/pageHeaders/pageHeaderWithClose.ejs", { heading: "New category", closeButtonPath: "/categories"}) %>
 <section class="px-8 flex-1">
   <%- include("../components/errorsList") %>
   <%- include("../components/forms/categoryForm", { route: "/categories/new"}) %>

--- a/src/views/pages/newCategory.ejs
+++ b/src/views/pages/newCategory.ejs
@@ -5,5 +5,5 @@
 </section>
 <footer class="flex gap-2 p-6 border border-base-200">
   <input type="submit" form="category-form" value="Save" class="btn btn-primary" />
-  <button type="button" class="btn bg-white text-gray-500 border-gray-400" onclick="history.back()">Cancel</button>
+  <a role="button" class="btn bg-white text-gray-500 border-gray-400" href="/categories">Cancel</a>
 </footer>

--- a/src/views/pages/newItem.ejs
+++ b/src/views/pages/newItem.ejs
@@ -1,11 +1,11 @@
-<%- include("../components/pageHeaders/pageHeaderWithClose.ejs", { heading: "New item "}) %>
+<%- include("../components/pageHeaders/pageHeaderWithClose.ejs", { heading: "New item", closeButtonPath: paths.previousPage}) %>
 <section class="px-8 flex-1">
   <%- include("../components/errorsList") %>
-  <%- include("../components/forms/itemForm", { formSubmitRoute: routes.formSubmitRoute }) %>
+  <%- include("../components/forms/itemForm", { formSubmitRoute: paths.submit }) %>
 </section>
 <footer class="flex gap-2 p-6 border border-base-200">
   <input type="submit" form="item-form" value="Save" class="btn btn-primary" />
-  <a href="<%= routes.redirectRoute %>">
+  <a href="<%= paths.previousPage %>">
     <button type="button" class="btn bg-white text-gray-500 border-gray-400">Cancel</button>
   </a>
 </footer>


### PR DESCRIPTION
This PR aims to fix page navigation issues, and includes:

1. **Cancel buttons in page footers**: these no longer just go to `history.back()`, causing the issues identified in #106. This PR fixes #106.
2. **Close buttons in page headers**: this is the equivalent for #106, and the "x" buttons in headers has same expected behaviour as "Cancel" - fixes #121
3. **Save buttons for 'Edit item' page**: this also needs to be dynamic, as the `res.redirect(...)` at the end of the POST request controller had previously lost all the query parameters holding both the category ID and which page took the user to that 'Edit item' page. Thankfully there are only 3 pages, so this was manually tested ("All items" page, category details page, a category's "Manage items" page). 
4. **Refactoring of helpers to get paths**: point 3 above was actually already solved for the '_New_ item' page, so now a refactoring effort was done to align how these are used. Essentially, the two helper functions look like this - but until we have TypeScript (#85), this is not hard-enforced 😞 Here it is in TypeScript anyway to document how it works
```ts
import { Request } from "express";

type Paths = {
    submit: string; // path for submitting the form, in action= attribute
    previousPage: string; // path for the previous page, so user is routed back there onCancel or after saving
}

const getPathsForNewItemPage = (req: Request): Paths => { ... }
const getPathsForEditItemPage= (req: Request): Paths => { ... }
```
6. **Fix redirection path when saving new item**: because of PR #115, where a user can 'add a new item' for purposes of inclusion into an existing category had changed, so this route had to be updated - fixes #120 